### PR TITLE
Fix gem dependency in gemspec

### DIFF
--- a/fluent-plugin-map.gemspec
+++ b/fluent-plugin-map.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rake", "~> 0.9.2.2"
-  s.add_development_dependency "fluentd", "~> 0.10.24"
+  s.add_development_dependency "fluentd", [">= 0.10.24", "< 2"]
   s.add_development_dependency "test-unit", "~> 3.1"
 end

--- a/fluent-plugin-map.gemspec
+++ b/fluent-plugin-map.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake", "~> 0.9.2.2"
   s.add_development_dependency "fluentd", "~> 0.10.24"
+  s.add_development_dependency "test-unit", "~> 3.1"
 end


### PR DESCRIPTION
- Ruby 2.2 does not provide minitest with test-unit compatible layer.
- AFAIK, there is no breaking changes between Fluentd 0.12 and 0.10.
