### PR TITLE
Create map rules with singleton_class.module_eval

### DIFF
--- a/lib/fluent/plugin/out_map.rb
+++ b/lib/fluent/plugin/out_map.rb
@@ -1,3 +1,4 @@
+require "erb"
 
 module Fluent
   class MapOutput < Fluent::Output
@@ -24,6 +25,8 @@ module Fluent
       @format = determine_format()
       configure_format()
       @map = create_map(conf)
+      erb = ERB.new("<% @map_result = #{@map} %>")
+      erb.def_method(self.class, "map(tag, time, record)", __FILE__)
     end
 
     def determine_format()
@@ -132,7 +135,8 @@ module Fluent
     def generate_tuples(tag, es)
       tuples = []
       es.each {|time, record|
-        new_tuple = eval(@map)
+        map(tag, time, record)
+        new_tuple = @map_result
         tuples.concat new_tuple
       }
       tuples

--- a/lib/fluent/plugin/out_map.rb
+++ b/lib/fluent/plugin/out_map.rb
@@ -25,8 +25,11 @@ module Fluent
       @format = determine_format()
       configure_format()
       @map = create_map(conf)
-      erb = ERB.new("<% @map_result = #{@map} %>")
-      erb.def_method(self.class, "map(tag, time, record)", __FILE__)
+      singleton_class.module_eval(<<-CODE)
+        def map_func(tag, time, record)
+          #{@map}
+        end
+      CODE
     end
 
     def determine_format()
@@ -135,8 +138,7 @@ module Fluent
     def generate_tuples(tag, es)
       tuples = []
       es.each {|time, record|
-        map(tag, time, record)
-        new_tuple = @map_result
+        new_tuple = map_func(tag, time, record)
         tuples.concat new_tuple
       }
       tuples

--- a/test/plugin/test_out_map.rb
+++ b/test/plugin/test_out_map.rb
@@ -57,11 +57,9 @@ class MapOutputTest < Test::Unit::TestCase
     syntax_error_config = %[
       map tag.
     ]
-    d1 = create_driver(syntax_error_config, tag)
-    es = Fluent::OneEventStream.new(time, record)
-    chain = Fluent::Test::TestOutputChain.new
-    e =  d1.instance.emit(tag, es, chain)
-    assert e.kind_of?(SyntaxError)
+    assert_raise SyntaxError do
+      d1 = create_driver(syntax_error_config, tag)
+    end
   end
 
   def test_syntax_error2
@@ -173,22 +171,19 @@ class MapOutputTest < Test::Unit::TestCase
     }
   end
 
-  def test_timeout
+  def test_config_error_sleep
     tag = 'tag'
     time = Time.local(2012, 10, 10, 10, 10, 10).to_i
     record = {'code' => '300'}
 
-    d1 = create_driver %[
-      key "newtag"
-      time sleep 10
-      record record
-      timeout 1s
-    ], tag
-    d1.run do
-      d1.emit(record, time)
-    end
-    emits = d1.emits
-    assert_equal 0, emits.length
+    assert_raise(SyntaxError) {
+      create_driver %[
+        key "newtag"
+        time sleep 10
+        record record
+        timeout 1s
+      ], tag
+    }
   end
 
   # Add format test


### PR DESCRIPTION
* `sleep N` where N is greater than 0 will be forbidden
* raise SyntaxError in `#configure` phase

---

Here is a micro bench result:

bench:
```ruby
require "benchmark"

src = "[[tag, time, record['code'].to_i]]"
map = "#{src}"

tag = "foo"
time = 12345
record = {
  "code" => "400"
}

class A
end

a = A.new
a.singleton_class.module_eval(<<-CODE)
  def map_func(tag, time, record)
    #{map}
  end
CODE

p a.map_func(tag, time, record)
p eval(src)
N = 10000
Benchmark.bmbm do |x|
  x.report("singleton_class.module_eval") do
    N.times do
      a.map_func(tag, time, record)
    end
  end
  x.report("eval") do
    N.times do
      eval(src)
    end
  end
end
```

result:
```
$ ruby bench.rb 
[["foo", 12345, 400]]
[["foo", 12345, 400]]
Rehearsal ---------------------------------------------------------------
singleton_class.module_eval   0.010000   0.000000   0.010000 (  0.008624)
eval                          0.130000   0.000000   0.130000 (  0.140426)
------------------------------------------------------ total: 0.140000sec

                                  user     system      total        real
singleton_class.module_eval   0.010000   0.000000   0.010000 (  0.005195)
eval                          0.120000   0.010000   0.130000 (  0.126949)
```